### PR TITLE
require forecast >= 8.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Depends: R (>= 3.4.2), Mcomp, Tcomp
 Imports:
   stats,
   purrr,
-  forecast
+  forecast (>= 8.3)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
The packages imports `mstl` from "forecast" 8.3, so require a version that has this.

For what it is worth, I was also able to install this on R 3.3.1 by modifying DESCRIPTION (and there aren't any obvious reasons preventing going back yet further), so the R version requirement could be backed down to the same as "forecast" (>= 3.0.2) if you like.